### PR TITLE
Fixed GameViewSizeApplyerGUI text color 

### DIFF
--- a/Assets/Editor/GameViewSizeChanger/GameViewSizeApplyer/GameViewSizeApplyerGUI.cs
+++ b/Assets/Editor/GameViewSizeChanger/GameViewSizeApplyer/GameViewSizeApplyerGUI.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using UnityEditor;
 
 namespace Syy.GameViewSizeChanger
 {
@@ -16,7 +17,10 @@ namespace Syy.GameViewSizeChanger
             {
                 GUI.color = Color.gray;
             }
-            if (GUILayout.Button(data.ToText(), "box", GUILayout.ExpandWidth(true)))
+
+            var style = new GUIStyle(GUI.skin.box);
+            style.normal.textColor = EditorStyles.toolbar.normal.textColor;
+            if (GUILayout.Button(data.ToText(), style, GUILayout.ExpandWidth(true)))
             {
                 GUI.color = defaultColor;
                 return true;


### PR DESCRIPTION
It's not visible if it's a professional EditorSkin, so I changed the color to match the EditorSkin.

- Before
![スクリーンショット 2019-03-28 19 07 59](https://user-images.githubusercontent.com/12096121/55149129-eb82cd00-518c-11e9-852d-4347b8dbc2cd.png)


- After
![スクリーンショット 2019-03-28 19 03 28](https://user-images.githubusercontent.com/12096121/55148778-36501500-518c-11e9-998a-c787c6e6f739.png) ![スクリーンショット 2019-03-28 19 03 11](https://user-images.githubusercontent.com/12096121/55148783-394b0580-518c-11e9-8ffb-5498ce9afa24.png)
